### PR TITLE
Fix traits logic

### DIFF
--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -149,7 +149,7 @@ export class Flagsmith {
         method: string,
         body?: { [key: string]: any }
     ): Promise<any> {
-        const headers: { [key: string]: any } = {};
+        const headers: { [key: string]: any } = {'Content-Type': 'application/json'};
         if (this.environmentKey) {
             headers['X-Environment-Key'] = this.environmentKey as string;
         }

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -3,7 +3,7 @@ import fetch, { Response } from 'node-fetch';
 if (typeof fetch.default !== 'undefined') fetch = fetch.default;
 
 export function generateIdentitiesData(identifier: string, traits?: { [key: string]: any }) {
-    const traitsGenerated = Object.values(traits || {}).map(trait => ({
+    const traitsGenerated = Object.entries(traits || {}).map(trait => ({
         trait_key: trait[0],
         trait_value: trait[1]
     }));


### PR DESCRIPTION
This PR fixes 2 issues: 

 1. Getting identity flags was previously throwing a 415 due to the lack of the Content-Type header
 2. Traits were being generated incorrectly due to the use of `Object.values` instead of `Object.entries`