### PR TITLE
Pass timeout values to node-fetch in ms, not seconds

### DIFF
--- a/sdk/analytics.ts
+++ b/sdk/analytics.ts
@@ -10,7 +10,7 @@ export class AnalyticsProcessor {
     private environmentKey: string;
     private lastFlushed: number;
     analyticsData: { [key: string]: any };
-    private timeout: number = 3;
+    private timeout: number = 3; // seconds
     /**
      * AnalyticsProcessor is used to track how often individual Flags are evaluated within 
      * the Flagsmith SDK. Docs: https://docs.flagsmith.com/advanced-use/flag-analytics.
@@ -38,7 +38,7 @@ export class AnalyticsProcessor {
         await fetch(this.analyticsEndpoint, {
             method: 'POST',
             body: JSON.stringify(this.analyticsData),
-            timeout: this.timeout,
+            timeout: this.timeout * 1000, // ms
             headers: {
                 'Content-Type': 'application/json',
                 'X-Environment-Key': this.environmentKey

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -20,11 +20,11 @@ export const retryFetch = (
     url: string,
     fetchOptions: any,
     retries = 3,
-    timeout: number
+    timeout: number // seconds
 ): Promise<Response> => {
     return new Promise((resolve, reject) => {
         // check for timeout
-        if (timeout) setTimeout(() => reject('error: timeout'), timeout);
+        if (timeout) setTimeout(() => reject('error: timeout'), timeout * 1000);
 
         const wrapper = (n: number) => {
             fetch(url, fetchOptions)


### PR DESCRIPTION
I noticed that although the SDK offers a `requestTimeoutSeconds` param, it was not being converted to ms before being passed to `node-fetch`'s timeout option (which expects a value in ms).