### PR TITLE
Fix default Flagsmith export in generated types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,3 @@
-import Flagsmith from './sdk';
-
 export {
   AnalyticsProcessor,
   FlagsmithAPIError,
@@ -7,7 +5,8 @@ export {
   EnvironmentDataPollingManager,
   FlagsmithCache,
   DefaultFlag,
-  Flags
+  Flags,
+  default
 } from './sdk';
 
 export {
@@ -19,5 +18,3 @@ export {
   SegmentModel,
   OrganisationModel
 } from './flagsmith-engine';
-
-module.exports = Flagsmith;


### PR DESCRIPTION
# Description

I found an issue with the library generated `.d.ts` types when importing the `flagsmith-nodejs` package. When trying to do `import Flagsmith from 'flagsmith-nodejs'`, it does work but the type check fails as TypeScript doesn't play well with the current `module.exports = Flagsmith` line [here](https://github.com/Flagsmith/flagsmith-nodejs-client/blob/8efdc989ed5042ee3a9f5c4c8ad85885d05724de/index.ts#L23).

The current generated types look like this:

```ts
export { AnalyticsProcessor, FlagsmithAPIError, FlagsmithClientError, EnvironmentDataPollingManager, FlagsmithCache, DefaultFlag, Flags } from './sdk';
export { EnvironmentModel, IntegrationModel, FeatureStateModel, IdentityModel, TraitModel, SegmentModel, OrganisationModel } from './flagsmith-engine';
```

After the changes in this PR, they look like this:

```ts
export { AnalyticsProcessor, FlagsmithAPIError, FlagsmithClientError, EnvironmentDataPollingManager, FlagsmithCache, DefaultFlag, Flags, default } from './sdk';
export { EnvironmentModel, IntegrationModel, FeatureStateModel, IdentityModel, TraitModel, SegmentModel, OrganisationModel } from './flagsmith-engine';
```

The main difference is the `default` export in the line exporting from the './sdk' file.

The current workaround is to import from 'sdk' like:

```ts
import Flagsmith from 'flagsmith-nodejs/sdk'
```