### PR TITLE
Provide cleanup method for polling manager

### DIFF
--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -253,6 +253,10 @@ export class Flagsmith {
         }
     }
 
+    async close() {
+        this.environmentDataPollingManager?.stop();
+    }
+
     private async getJSONResponse(
         url: string,
         method: string,


### PR DESCRIPTION
Currently, there's no externally expose API to cleanup the `setInterval()` created by the polling manager class. This PR introduces a external close() method to provide this functionality