### PR TITLE
fix(getIdentityFlags): Propagate errors from inner promises in sdk

### DIFF
--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -152,10 +152,10 @@ export class Flagsmith {
             return cachedItem;
         }
         if (this.enableLocalEvaluation) {
-            return new Promise(resolve =>
+            return new Promise((resolve, reject) =>
                 this.environmentPromise!.then(() => {
                     resolve(this.getEnvironmentFlagsFromDocument());
-                })
+                }).catch((e) => reject(e))
             );
         }
         if (this.environment) {
@@ -182,10 +182,10 @@ export class Flagsmith {
         }
         traits = traits || {};
         if (this.enableLocalEvaluation) {
-            return new Promise(resolve =>
+            return new Promise((resolve, reject) =>
                 this.environmentPromise!.then(() => {
                     resolve(this.getIdentityFlagsFromDocument(identifier, traits || {}));
-                })
+                }).catch(e => reject(e))
             );
         }
         return this.getIdentityFlagsFromApi(identifier, traits);
@@ -208,8 +208,8 @@ export class Flagsmith {
     ): Promise<SegmentModel[]> {
         traits = traits || {};
         if (this.enableLocalEvaluation) {
-            return this.environmentPromise!.then(() => {
-                return new Promise(resolve => {
+            return new Promise((resolve, reject) => {
+                return this.environmentPromise!.then(() => {
                     const identityModel = this.buildIdentityModel(
                         identifier,
                         Object.keys(traits || {}).map(key => ({
@@ -220,7 +220,7 @@ export class Flagsmith {
 
                     const segments = getIdentitySegments(this.environment, identityModel);
                     return resolve(segments);
-                });
+                }).catch((e) => reject(e));
             });
         }
         console.error('This function is only permitted with local evaluation.');


### PR DESCRIPTION
If `enableLocalEvaluation` is set to true, the rejection from `this.environmentPromise` may not be handled leading to a crash in the parent nodejs process which is using this library.

(Crash log for reference)

```
 node:internal/process/promises:279
 
            triggerUncaughtException(err, true /* fromPromise */);
 
            ^
 
 
[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "error: timeout".] {
 
  code: 'ERR_UNHANDLED_REJECTION'
 
}
```

"error: timeout" originates from https://github.com/Flagsmith/flagsmith-nodejs-client/blob/8efdc989ed5042ee3a9f5c4c8ad85885d05724de/sdk/utils.ts#L27