### PR TITLE
Fix issue with local evaluation of multivariate flags

### DIFF
--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -323,7 +323,8 @@ export class Flagsmith {
         const flags = Flags.fromFeatureStateModels({
             featureStates: featureStates,
             analyticsProcessor: this.analyticsProcessor,
-            defaultFlagHandler: this.defaultFlagHandler
+            defaultFlagHandler: this.defaultFlagHandler,
+            identityID: identityModel.djangoID || identityModel.identityUuid
         });
 
         if (!!this.cache) {

--- a/tests/sdk/data/environment.json
+++ b/tests/sdk/data/environment.json
@@ -63,8 +63,30 @@
         "type": "STANDARD",
         "id": 1
       },
-      "segment_id": null,
+      "feature_segment": null,
       "enabled": true
+    },
+    {
+      "multivariate_feature_state_values": [
+        {
+          "percentage_allocation": 100,
+          "multivariate_feature_option": {
+            "value": "bar",
+            "id": 1
+          },
+          "mv_fs_value_uuid": "42d5cdf9-8ec9-4b8d-a3ca-fd43c64d5f05",
+          "id": 1
+        }
+      ],
+      "feature_state_value": "foo",
+      "feature": {
+        "name": "mv_feature",
+        "type": "MULTIVARIATE",
+        "id": 2
+      },
+      "feature_segment": null,
+      "featurestate_uuid": "96fc3503-09d7-48f1-a83b-2dc903d5c08a",
+      "enabled": false
     }
   ]
 }

--- a/tests/sdk/flagsmith-identity-flags.test.ts
+++ b/tests/sdk/flagsmith-identity-flags.test.ts
@@ -27,7 +27,7 @@ test('test_get_identity_flags_calls_api_when_no_local_environment_no_traits', as
   expect(identityFlags[0].featureName).toBe('some_feature');
 });
 
-test('test_get_identity_flags_calls_api_when_local_environment_no_traits', async () => {
+test('test_get_identity_flags_uses_environment_when_local_environment_no_traits', async () => {
   // @ts-ignore
   fetch.mockReturnValue(Promise.resolve(new Response(environmentJSON())));
   const identifier = 'identifier';
@@ -138,3 +138,20 @@ test('test_default_flag_is_used_when_no_identity_flags_returned_and_no_custom_de
   expect(flag.enabled).toBe(false);
 });
 
+
+test('test_get_identity_flags_multivariate_value_with_local_evaluation_enabled', async () => {
+  // @ts-ignore
+  fetch.mockReturnValue(Promise.resolve(new Response(environmentJSON())));
+  const identifier = 'identifier';
+
+  const flg = flagsmith({
+      environmentKey: 'ser.key',
+      enableLocalEvaluation: true,
+
+  });
+
+  const identityFlags = (await flg.getIdentityFlags(identifier))
+
+  expect(identityFlags.getFeatureValue('mv_feature')).toBe('bar');
+  expect(identityFlags.isFeatureEnabled('mv_feature')).toBe(false);
+});

--- a/tests/sdk/flagsmith.test.ts
+++ b/tests/sdk/flagsmith.test.ts
@@ -45,16 +45,11 @@ test('test_update_environment_sets_environment', async () => {
     await flg.updateEnvironment();
     expect(flg.environment).toBeDefined();
 
-    // @ts-ignore
-    flg.environment.featureStates[0].featurestateUUID = undefined;
-    // @ts-ignore
-    flg.environment.project.segments[0].featureStates[0].featurestateUUID = undefined;
-    // @ts-ignore
     const model = environmentModel(JSON.parse(environmentJSON()));
-    // @ts-ignore
-    model.featureStates[0].featurestateUUID = undefined;
-    // @ts-ignore
-    model.project.segments[0].featureStates[0].featurestateUUID = undefined;
+
+    wipeFeatureStateUUIDs(flg.environment)
+    wipeFeatureStateUUIDs(model)
+
     expect(flg.environment).toStrictEqual(model);
 });
 
@@ -231,3 +226,24 @@ test('test onEnvironmentChange is called after error', async () => {
 
     expect(callbackSpy).toBeCalled();
 });
+
+
+
+async function wipeFeatureStateUUIDs (enviromentModel: EnvironmentModel) {
+    // TODO: this has been pulled out of tests above as a helper function.
+    //  I'm not entirely sure why it's necessary, however, we should look to remove.
+    enviromentModel.featureStates.forEach(fs => {
+        // @ts-ignore
+        fs.featurestateUUID = undefined;
+        fs.multivariateFeatureStateValues.forEach(mvfsv => {
+            // @ts-ignore
+            mvfsv.mvFsValueUuid = undefined;
+        })
+    });
+    enviromentModel.project.segments.forEach(s => {
+        s.featureStates.forEach(fs => {
+            // @ts-ignore
+            fs.featurestateUUID = undefined;
+        })
+    })
+}


### PR DESCRIPTION
Currently, when using local evaluation, multivariate flag evaluations are not working since we're not passing the identity ID to the engine when evaluating the flags. 

This PR ensures that the identityID is passed. 