### PR TITLE
Ensure local evaluation returns consistent MV values

### DIFF
--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -329,7 +329,7 @@ export class Flagsmith {
             featureStates: featureStates,
             analyticsProcessor: this.analyticsProcessor,
             defaultFlagHandler: this.defaultFlagHandler,
-            identityID: identityModel.djangoID || identityModel.identityUuid
+            identityID: identityModel.djangoID || identityModel.compositeKey
         });
 
         if (!!this.cache) {

--- a/tests/engine/unit/utils/utils.test.ts
+++ b/tests/engine/unit/utils/utils.test.ts
@@ -1,0 +1,62 @@
+import { v4 as uuidv4 } from 'uuid';
+import { getHashedPercentateForObjIds } from '../../../../flagsmith-engine/utils/hashing';
+
+describe('getHashedPercentageForObjIds', () => {
+    it.each([
+        [[12, 93]],
+        [[uuidv4(), 99]],
+        [[99, uuidv4()]],
+        [[uuidv4(), uuidv4()]]
+    ])('returns x where 0 <= x < 100', (objIds: (string|number)[]) => {
+        let result = getHashedPercentateForObjIds(objIds);
+        expect(result).toBeLessThan(100);
+        expect(result).toBeGreaterThanOrEqual(0);
+    });
+
+    it.each([
+        [[12, 93]],
+        [[uuidv4(), 99]],
+        [[99, uuidv4()]],
+        [[uuidv4(), uuidv4()]]
+    ])('returns the same value each time', (objIds: (string|number)[]) => {
+        let resultOne = getHashedPercentateForObjIds(objIds);
+        let resultTwo = getHashedPercentateForObjIds(objIds);
+        expect(resultOne).toEqual(resultTwo);
+    })
+
+    it('is unique for different object ids', () => {
+        let resultOne = getHashedPercentateForObjIds([14, 106]);
+        let resultTwo = getHashedPercentateForObjIds([53, 200]);
+        expect(resultOne).not.toEqual(resultTwo);
+    })
+
+    it('is evenly distributed', () => {
+        // copied from python test here:
+        // https://github.com/Flagsmith/flagsmith-engine/blob/main/tests/unit/utils/test_utils_hashing.py#L56
+        const testSample = 500;
+        const numTestBuckets = 50;
+        const testBucketSize = Math.floor(testSample / numTestBuckets)
+        const errorFactor = 0.1
+
+        // Given
+        let objectIdPairs = Array.from(Array(testSample).keys()).flatMap(d => Array.from(Array(testSample).keys()).map(e => [d, e].flat()))
+
+        // When
+        console.log(objectIdPairs);
+        let values = objectIdPairs.map((objIds) => getHashedPercentateForObjIds(objIds));
+
+        // Then
+        for (let i = 0; i++; i < numTestBuckets) {
+            let bucketStart = i * testBucketSize;
+            let bucketEnd = (i + 1) * testBucketSize;
+            let bucketValueLimit = Math.min(
+                (i + 1) / numTestBuckets + errorFactor + ((i + 1) / numTestBuckets),
+                1
+            )
+
+            for (let i = bucketStart; i++; i < bucketEnd) {
+                expect(values[i]).toBeLessThanOrEqual(bucketValueLimit);
+            }
+        }
+    })
+})


### PR DESCRIPTION
Fixes a bug where MV values were not consistent on different evaluations for the same identity. This was caused by the fact that we were using the (transient) identityUuid property of the identity rather than the (idempotent) compositeKey. 

Note that as part of this work, I've also added the missing tests for the percentage value hashing logic. 