### PR TITLE
Fix timeout not using default flags

### DIFF
--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -283,11 +283,11 @@ export class Flagsmith {
             {
                 agent: this.agent,
                 method: method,
-                timeout: this.requestTimeoutMs || undefined,
                 body: JSON.stringify(body),
                 headers: headers
             },
-            this.retries
+            this.retries,
+            this.requestTimeoutMs || undefined,
         );
 
         if (data.status !== 200) {

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -28,7 +28,7 @@ export const retryFetch = (
                 .then(res => resolve(res))
                 .catch(async err => {
                     if (n > 0) {
-                        await delay(250);
+                        await delay(1000);
                         wrapper(--n);
                     } else {
                         reject(err);
@@ -37,12 +37,8 @@ export const retryFetch = (
         };
 
         const requestWrapper = (): Promise<Response> => {
-            return new Promise((resolve, reject) => {
-                if (timeout) setTimeout(() => reject('error: timeout'), timeout);
-                fetch(url, fetchOptions)
-                    .then(res => resolve(res))
-                    .catch(err => reject(err))
-            })
+            if (timeout) setTimeout(() => reject('error: timeout'), timeout);
+            return fetch(url, fetchOptions);
         }
 
         wrapper(retries);

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -23,13 +23,13 @@ export const retryFetch = (
     timeout?: number // set an overall timeout for this function
 ): Promise<Response> => {
     return new Promise((resolve, reject) => {
-        const wrapper = (n: number) => {
+        const retryWrapper = (n: number) => {
             requestWrapper()
                 .then(res => resolve(res))
                 .catch(async err => {
                     if (n > 0) {
                         await delay(1000);
-                        wrapper(--n);
+                        retryWrapper(--n);
                     } else {
                         reject(err);
                     }
@@ -45,6 +45,6 @@ export const retryFetch = (
             })
         }
 
-        wrapper(retries);
+        retryWrapper(retries);
     });
 };

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -28,7 +28,7 @@ export const retryFetch = (
                 .then(res => resolve(res))
                 .catch(async err => {
                     if (n > 0) {
-                        await delay(1000);
+                        await delay(250);
                         wrapper(--n);
                     } else {
                         reject(err);
@@ -37,8 +37,12 @@ export const retryFetch = (
         };
 
         const requestWrapper = (): Promise<Response> => {
-            if (timeout) setTimeout(() => reject('error: timeout'), timeout);
-            return fetch(url, fetchOptions);
+            return new Promise((resolve, reject) => {
+                if (timeout) setTimeout(() => reject('error: timeout'), timeout);
+                return fetch(url, fetchOptions)
+                    .then(res => resolve(res))
+                    .catch(err => reject(err))
+            })
         }
 
         wrapper(retries);

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -28,7 +28,7 @@ export const retryFetch = (
                 .then(res => resolve(res))
                 .catch(async err => {
                     if (n > 0) {
-                        await delay(250);
+                        await delay(1000);
                         wrapper(--n);
                     } else {
                         reject(err);

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -23,21 +23,27 @@ export const retryFetch = (
     timeout?: number // set an overall timeout for this function
 ): Promise<Response> => {
     return new Promise((resolve, reject) => {
-        // check for timeout
-        if (timeout) setTimeout(() => reject('error: timeout'), timeout);
-
         const wrapper = (n: number) => {
-            fetch(url, fetchOptions)
+            requestWrapper()
                 .then(res => resolve(res))
                 .catch(async err => {
                     if (n > 0) {
-                        await delay(1000);
+                        await delay(250);
                         wrapper(--n);
                     } else {
                         reject(err);
                     }
                 });
         };
+
+        const requestWrapper = (): Promise<Response> => {
+            return new Promise((resolve, reject) => {
+                if (timeout) setTimeout(() => reject('error: timeout'), timeout);
+                fetch(url, fetchOptions)
+                    .then(res => resolve(res))
+                    .catch(err => reject(err))
+            })
+        }
 
         wrapper(retries);
     });

--- a/tests/engine/unit/utils/utils.test.ts
+++ b/tests/engine/unit/utils/utils.test.ts
@@ -42,7 +42,6 @@ describe('getHashedPercentageForObjIds', () => {
         let objectIdPairs = Array.from(Array(testSample).keys()).flatMap(d => Array.from(Array(testSample).keys()).map(e => [d, e].flat()))
 
         // When
-        console.log(objectIdPairs);
         let values = objectIdPairs.map((objIds) => getHashedPercentateForObjIds(objIds));
 
         // Then


### PR DESCRIPTION
This fixes an issue where the client was not falling back to the defaultFlagHandler when a timeout was reached requesting the data from the API. 

To resolve this, I have ensured that the timeout is used on requests to the API (as I believe it was not previously as `timeout` does not seem to be a valid option to provide to the `node-fetch` library). I have also adjusted the logic slightly such that each request implements the timeout, separate from the retry logic which is how our other libraries handle it. 