### PR TITLE
Lazily calculate the hash

### DIFF
--- a/flagsmith-engine/features/models.ts
+++ b/flagsmith-engine/features/models.ts
@@ -104,17 +104,18 @@ export class FeatureStateModel {
             return a.id - b.id;
         });
         for (const myValue of sortedF) {
-            if (myValue.percentageAllocation === 0) {
-                continue;
-            }
-            if (myValue.percentageAllocation === 100) {
-                return myValue.multivariateFeatureOption.value;
-            }
-            if (percentageValue === undefined) {
-                percentageValue = getHashedPercentateForObjIds([
-                    this.djangoID || this.featurestateUUID,
-                    identityID
-                ]);
+            switch (myValue.percentageAllocation) {
+                case 0:
+                    continue;
+                case 100:
+                    return myValue.multivariateFeatureOption.value;
+                default:
+                    if (percentageValue === undefined) {
+                        percentageValue = getHashedPercentateForObjIds([
+                            this.djangoID || this.featurestateUUID,
+                            identityID
+                        ]);
+                    }
             }
             const limit = myValue.percentageAllocation + startPercentage;
             if (startPercentage <= percentageValue && percentageValue < limit) {

--- a/flagsmith-engine/features/models.ts
+++ b/flagsmith-engine/features/models.ts
@@ -96,18 +96,26 @@ export class FeatureStateModel {
         }
         return this.featureSegment.priority < other.featureSegment.priority;
     }
-    
-    getMultivariateValue(identityID: number | string) {
-        const percentageValue = getHashedPercentateForObjIds([
-            this.djangoID || this.featurestateUUID,
-            identityID
-        ]);
 
+    getMultivariateValue(identityID: number | string) {
+        let percentageValue: number | undefined;
         let startPercentage = 0;
-        const sortedF = this.multivariateFeatureStateValues.sort((a, b) =>{
+        const sortedF = this.multivariateFeatureStateValues.sort((a, b) => {
             return a.id - b.id;
         });
         for (const myValue of sortedF) {
+            if (myValue.percentageAllocation === 0) {
+                continue;
+            }
+            if (myValue.percentageAllocation === 100) {
+                return myValue.multivariateFeatureOption.value;
+            }
+            if (percentageValue === undefined) {
+                percentageValue = getHashedPercentateForObjIds([
+                    this.djangoID || this.featurestateUUID,
+                    identityID
+                ]);
+            }
             const limit = myValue.percentageAllocation + startPercentage;
             if (startPercentage <= percentageValue && percentageValue < limit) {
                 return myValue.multivariateFeatureOption.value;


### PR DESCRIPTION
We had the following use-case: around 70 feature flags, most of which are either fully turned on or off.

Because `md5` hash is calculated for every feature flag, `getIdentityFlags` with local evaluation ended up taking 30-40ms.

The pr lazily calls `getHashedPercentateForObjIds` only when needed, and skips it for cases when it's not necessary (0 and 100%). With the patch `getIdentityFlags` executes in ~3ms.

Please let me know if something is missing or needs changing. Have a nice day!