### PR TITLE
Chore: Bump version to 3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-nodejs",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-nodejs",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Flagsmith lets you manage features flags and remote config across web, mobile and server side applications. Deliver true Continuous Integration. Get builds out faster. Control who has access to new features.",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
Version 3.1.1
Fixes issue with the default request timeout no being set to 10 seconds.