### PR TITLE
Local Evaluation without awaiting a Promise

### DIFF
--- a/sdk/polling_manager.ts
+++ b/sdk/polling_manager.ts
@@ -27,4 +27,6 @@ export class EnvironmentDataPollingManager {
         }
         clearInterval(this.interval);
     }
+
+    get isStopped() { return !!this.interval }
 }

--- a/sdk/types.ts
+++ b/sdk/types.ts
@@ -5,7 +5,7 @@ import { Logger } from "pino";
 import { BaseOfflineHandler } from "./offline_handlers";
 
 export interface FlagsmithCache {
-  get(key: string): Promise<Flags|undefined> | undefined;
+  get(key: string): Promise<Flags|undefined> | Flags | undefined;
   set(key: string, value: Flags, ttl: string | number): boolean | Promise<boolean>;
   has(key: string): boolean | Promise<boolean>;
   [key: string]: any;

--- a/tests/sdk/flagsmith-identity-flags.test.ts
+++ b/tests/sdk/flagsmith-identity-flags.test.ts
@@ -155,3 +155,46 @@ test('test_get_identity_flags_multivariate_value_with_local_evaluation_enabled',
   expect(identityFlags.getFeatureValue('mv_feature')).toBe('bar');
   expect(identityFlags.isFeatureEnabled('mv_feature')).toBe(false);
 });
+
+test('test_get_identity_flags_sync_basic', async () => {
+  // @ts-ignore
+  fetch.mockReturnValue(Promise.resolve(new Response(environmentJSON())));
+  const identifier = 'identifier';
+
+  const flg = flagsmith({
+      environmentKey: 'ser.key',
+      enableLocalEvaluation: true,
+  });
+
+  await flg.readyCheck();
+
+  const identityFlags = flg.getIdentityFlagsSync(identifier);
+
+  expect(identityFlags.getFeatureValue('mv_feature')).toBe('bar');
+  expect(identityFlags.isFeatureEnabled('mv_feature')).toBe(false);
+});
+
+test('test_get_identity_flags_sync_errors', async () => {
+  // @ts-ignore
+  fetch.mockReturnValue(Promise.resolve(new Response(environmentJSON())));
+
+  const flg = flagsmith({
+      environmentKey: 'ser.key',
+      enableLocalEvaluation: true,
+  });
+  expect(() => {
+    flg.getIdentityFlagsSync('example');
+  }).toThrow('not loaded yet');
+  await flg.readyCheck();
+  expect(() => {
+    flg.getIdentityFlagsSync('');
+  }).toThrow('missing or invalid');
+
+  const f2 = flagsmith({
+      environmentKey: 'ser.key',
+      enableLocalEvaluation: false,
+  });
+  expect(() => {
+    f2.getIdentityFlagsSync('example');
+  }).toThrow('not enabled');
+});

--- a/tests/sdk/utils.ts
+++ b/tests/sdk/utils.ts
@@ -24,6 +24,23 @@ export class TestCache implements FlagsmithCache {
     }
 }
 
+export class TestCacheSync implements FlagsmithCache {
+    cache: Record<string, Flags> = {};
+
+    get(name: string): Flags|undefined {
+        return this.cache[name];
+    }
+
+    has(name: string): boolean {
+        return !!this.cache[name];
+    }
+
+    set(name: string, value: Flags, ttl: number|string): boolean {
+        this.cache[name] = value;
+        return true
+    }
+}
+
 export function analyticsProcessor() {
     return new AnalyticsProcessor({
         environmentKey: 'test-key',


### PR DESCRIPTION
- ~rm whitespace~
- ~rm superfluous updateEnvironment(); this was called 2x in local evaluation mode startup. Let the polling manager make the first call.~
- add `getIdentityFlagsSync()`; expects local evaluation or offline mode, and a synchronous cache. Does not return a Promise.
- add `readyCheck()` Wait for the environment document to load. If the request fails then this promise is rejected. Useful for local evaluation mode.


I was rather confused that, with local evaluation mode, retrieving flags is still an async operation! Promises are entirely unnecessary in this particular situation. In fact, it forces any calling code to be async too which can be quite annoying. Once the environment document is first loaded, I should be able to check my flags in a simple synchronous fashion, while the environment updates in the background.

```javascript
const flagsmith = new Flagsmith({
  enableLocalEvaluation: true
})

// need to wait for first load
await flagsmith.readyCheck()

// now evaluate with in-memory document
const flags =  flagsmith.getIdentityFlagsSync('unknown_user')
console.log(flags)
```
