### PR TITLE
Cancel timeout when it is no longer needed

### DIFF
--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -38,10 +38,18 @@ export const retryFetch = (
 
         const requestWrapper = (): Promise<Response> => {
             return new Promise((resolve, reject) => {
-                if (timeout) setTimeout(() => reject('error: timeout'), timeout);
+                let timeoutId: NodeJS.Timeout;
+                if (timeout) {
+                    timeoutId = setTimeout(() => reject('error: timeout'), timeout);
+                }
                 return fetch(url, fetchOptions)
                     .then(res => resolve(res))
                     .catch(err => reject(err))
+                    .finally(() => {
+                        if (timeoutId) {
+                            clearTimeout(timeoutId);
+                        }
+                    })
             })
         }
 


### PR DESCRIPTION
Once the fetch request completes, it is no longer necessary to wait for the timeout. Cancel it to clear the async stack

This is specifically an issue when using this library from within an AWS lambda, as the default handling waits for an empty event loop before allowing the lambda to complete.

> callbackWaitsForEmptyEventLoop – Set to false to send the response right away when the callback runs, instead of waiting for the Node.js event loop to be empty. If this is false, any outstanding events continue to run during the next invocation.

https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html

This seemed like a quick change that would be correct for other runtime environments, so I submitted this PR.