### PR TITLE
fix: env document fetched twice on startup

### DIFF
--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -163,7 +163,6 @@ export class Flagsmith {
                     this.environmentRefreshIntervalSeconds
                 );
                 this.environmentDataPollingManager.start();
-                this.updateEnvironment();
             }
 
             this.analyticsProcessor = data.enableAnalytics


### PR DESCRIPTION
When using local evaluation mode, the environment document is immediately fetched twice on when `Flagsmith` is instantiated. This can be observed by spinning up a dummy HTTP server:

```
python -m http.server
```

and then point the client to it:

```js
import Flagsmith from "flagsmith-nodejs"

const flagsmith = new Flagsmith({
  environmentKey: "ser.foo",
  apiUrl: "http://127.0.0.1:8000",
  enableLocalEvaluation: true,
})
```

On startup, we can see that `GET /environment-document` is immediately called twice:

```
::ffff:127.0.0.1 - - [29/Apr/2024 08:48:33] code 404, message File not found
::ffff:127.0.0.1 - - [29/Apr/2024 08:48:33] code 404, message File not found
::ffff:127.0.0.1 - - [29/Apr/2024 08:48:33] "GET /environment-document/ HTTP/1.1" 404 -
::ffff:127.0.0.1 - - [29/Apr/2024 08:48:33] "GET /environment-document/ HTTP/1.1" 404 -
```

I was hoping to add this to a test to make it fail, but it does not - something might be happening with Jest and `fetch` being called from a `setInterval`:

```patch
diff --git a/tests/sdk/flagsmith-environment-flags.test.ts b/tests/sdk/flagsmith-environment-flags.test.ts
index 6262762..33f9676 100644
--- a/tests/sdk/flagsmith-environment-flags.test.ts
+++ b/tests/sdk/flagsmith-environment-flags.test.ts
@@ -191,6 +191,7 @@ test('test_local_evaluation', async () => {
   const flags = await flg.getEnvironmentFlags();
   const flag = flags.getFlag('some_feature');
 
+  expect(fetch).toBeCalledTimes(1);
   expect(flag.isDefault).toBe(false);
   expect(flag.value).not.toBe(defaultFlag.value);
   expect(flag.value).toBe('some-value');
```