### PR TITLE
fix: error evaluating CONTAINS / NOT_CONTAINS for null traits

### DIFF
--- a/flagsmith-engine/segments/models.ts
+++ b/flagsmith-engine/segments/models.ts
@@ -27,7 +27,7 @@ export const matchingFunctions = {
         thisValue >= otherValue,
     [CONDITION_OPERATORS.NOT_EQUAL]: (thisValue: any, otherValue: any) => thisValue != otherValue,
     [CONDITION_OPERATORS.CONTAINS]: (thisValue: any, otherValue: any) =>
-        otherValue.includes(thisValue),
+        !!otherValue && otherValue.includes(thisValue),
 };
 
 export const semverMatchingFunction = {
@@ -64,6 +64,10 @@ export class SegmentConditionModel {
     matchesTraitValue(traitValue: any) {
         const evaluators: { [key: string]: CallableFunction } = {
             evaluateNotContains: (traitValue: any) => {
+                if (!traitValue) {
+                    // empty / undefined values will never contain the given key.
+                    return true
+                }
                 return !traitValue.includes(this.value);
             },
             evaluateRegex: (traitValue: any) => {

--- a/flagsmith-engine/segments/models.ts
+++ b/flagsmith-engine/segments/models.ts
@@ -64,11 +64,9 @@ export class SegmentConditionModel {
     matchesTraitValue(traitValue: any) {
         const evaluators: { [key: string]: CallableFunction } = {
             evaluateNotContains: (traitValue: any) => {
-                if (!traitValue) {
-                    // empty / undefined values will never contain the given key.
-                    return true
-                }
-                return !traitValue.includes(this.value);
+                return typeof traitValue == "string" &&
+                    !!this.value &&
+                    !traitValue.includes(this.value?.toString());
             },
             evaluateRegex: (traitValue: any) => {
                 return !!this.value && !!traitValue.match(new RegExp(this.value));

--- a/tests/engine/unit/segments/segments_model.test.ts
+++ b/tests/engine/unit/segments/segments_model.test.ts
@@ -61,7 +61,7 @@ const conditionMatchCases: [string, string | number | boolean | null, string, bo
     [CONDITION_OPERATORS.NOT_CONTAINS, 'bar', 'b', false],
     [CONDITION_OPERATORS.NOT_CONTAINS, 'bar', 'bar', false],
     [CONDITION_OPERATORS.NOT_CONTAINS, 'bar', 'baz', true],
-    [CONDITION_OPERATORS.NOT_CONTAINS, null, 'foo', true],
+    [CONDITION_OPERATORS.NOT_CONTAINS, null, 'foo', false],
     [CONDITION_OPERATORS.REGEX, 'foo', '[a-z]+', true],
     [CONDITION_OPERATORS.REGEX, 'FOO', '[a-z]+', false],
     [CONDITION_OPERATORS.EQUAL, "1.0.0", "1.0.0:semver", true],

--- a/tests/engine/unit/segments/segments_model.test.ts
+++ b/tests/engine/unit/segments/segments_model.test.ts
@@ -11,7 +11,7 @@ import {
     SegmentRuleModel
 } from '../../../../flagsmith-engine/segments/models';
 
-const conditionMatchCases: [string, string | number | boolean, string, boolean][] = [
+const conditionMatchCases: [string, string | number | boolean | null, string, boolean][] = [
     [CONDITION_OPERATORS.EQUAL, 'bar', 'bar', true],
     [CONDITION_OPERATORS.EQUAL, 'bar', 'baz', false],
     [CONDITION_OPERATORS.EQUAL, 1, '1', true],
@@ -57,9 +57,11 @@ const conditionMatchCases: [string, string | number | boolean, string, boolean][
     [CONDITION_OPERATORS.CONTAINS, 'bar', 'b', true],
     [CONDITION_OPERATORS.CONTAINS, 'bar', 'bar', true],
     [CONDITION_OPERATORS.CONTAINS, 'bar', 'baz', false],
+    [CONDITION_OPERATORS.CONTAINS, null, 'foo', false],
     [CONDITION_OPERATORS.NOT_CONTAINS, 'bar', 'b', false],
     [CONDITION_OPERATORS.NOT_CONTAINS, 'bar', 'bar', false],
     [CONDITION_OPERATORS.NOT_CONTAINS, 'bar', 'baz', true],
+    [CONDITION_OPERATORS.NOT_CONTAINS, null, 'foo', true],
     [CONDITION_OPERATORS.REGEX, 'foo', '[a-z]+', true],
     [CONDITION_OPERATORS.REGEX, 'FOO', '[a-z]+', false],
     [CONDITION_OPERATORS.EQUAL, "1.0.0", "1.0.0:semver", true],


### PR DESCRIPTION
This PR fixes #149 . 

Note that in keeping with [the python engine implementation](https://github.com/Flagsmith/flagsmith-engine/blob/main/flag_engine/segments/evaluator.py#L129), I ensured that `NOT_CONTAINS` returns false for non string values. 