### PR TITLE
fix: handle null traits for regex evaluations

### DIFF
--- a/flagsmith-engine/segments/models.ts
+++ b/flagsmith-engine/segments/models.ts
@@ -69,7 +69,7 @@ export class SegmentConditionModel {
                     !traitValue.includes(this.value?.toString());
             },
             evaluateRegex: (traitValue: any) => {
-                return !!this.value && !!traitValue.match(new RegExp(this.value));
+                return !!this.value && !!traitValue?.toString().match(new RegExp(this.value));
             },
             evaluateModulo: (traitValue: any) => {
                 if (isNaN(parseFloat(traitValue)) || !this.value) {

--- a/tests/engine/unit/segments/segments_model.test.ts
+++ b/tests/engine/unit/segments/segments_model.test.ts
@@ -64,6 +64,7 @@ const conditionMatchCases: [string, string | number | boolean | null, string, bo
     [CONDITION_OPERATORS.NOT_CONTAINS, null, 'foo', false],
     [CONDITION_OPERATORS.REGEX, 'foo', '[a-z]+', true],
     [CONDITION_OPERATORS.REGEX, 'FOO', '[a-z]+', false],
+    [CONDITION_OPERATORS.REGEX, null, '[a-z]+', false],
     [CONDITION_OPERATORS.EQUAL, "1.0.0", "1.0.0:semver", true],
     [CONDITION_OPERATORS.EQUAL, "1.0.0", "1.0.0:semver", true],
     [CONDITION_OPERATORS.EQUAL, "1.0.0", "1.0.1:semver", false],


### PR DESCRIPTION
This PR fixes an issue where the regex operator would throw an exception if the trait value was null. 

Note that this PR also converts any non-string traits to strings to match the behaviour of the python client as seen [here](https://github.com/Flagsmith/flagsmith-engine/blob/main/flag_engine/segments/evaluator.py#L136-L139). 