### PR TITLE
feat: Simplify FlagsmithCache interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flagsmith-nodejs",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flagsmith-nodejs",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "pino": "^8.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-nodejs",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Flagsmith lets you manage features flags and remote config across web, mobile and server side applications. Deliver true Continuous Integration. Get builds out faster. Control who has access to new features.",
   "main": "./build/cjs/index.js",
   "type": "module",

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -128,17 +128,6 @@ export class Flagsmith {
         }
 
         if (!!data.cache) {
-            const missingMethods: string[] = ['has', 'get', 'set'].filter(
-                method => data.cache && !data.cache[method]
-            );
-
-            if (missingMethods.length > 0) {
-                throw new Error(
-                    `Please implement the following methods in your cache: ${missingMethods.join(
-                        ', '
-                    )}`
-                );
-            }
             this.cache = data.cache;
         }
 

--- a/sdk/types.ts
+++ b/sdk/types.ts
@@ -5,11 +5,24 @@ import { Logger } from 'pino';
 import { BaseOfflineHandler } from './offline_handlers.js';
 
 export type IFlagsmithValue<T = string | number | boolean | null> = T;
+
+
+/**
+ * Stores and retrieves {@link Flags} from a cache.
+ */
 export interface FlagsmithCache {
-    get(key: string): Promise<Flags | undefined> | undefined;
-    set(key: string, value: Flags, ttl?: string | number): boolean | Promise<boolean>;
-    has(key: string): boolean | Promise<boolean>;
-    [key: string]: any;
+    /**
+     * Retrieve the cached {@link Flags} for the given environment or identity, or `undefined` if no cached value exists.
+     * @param key An environment ID or identity identifier, which is used as the cache key.
+     */
+    get(key: string): Promise<Flags | undefined>;
+
+    /**
+     * Persist an environment or identity's {@link Flags} in the cache.
+     * @param key An environment ID or identity identifier, which is used as the cache key.
+     * @param value The {@link Flags} to be stored in the cache.
+     */
+    set(key: string, value: Flags): Promise<void>;
 }
 
 export type Fetch = typeof fetch

--- a/tests/sdk/flagsmith-cache.test.ts
+++ b/tests/sdk/flagsmith-cache.test.ts
@@ -4,15 +4,6 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-test('test_wrong_cache_interface_throws_an_error', async () => {
-  const cache = {
-    set: () => { },
-    get: () => { },
-  };
-
-  expect(() => { const flg = flagsmith({ cache }); }).toThrow();
-});
-
 test('test_empty_cache_not_read_but_populated', async () => {
   fetch.mockResolvedValue(new Response(flagsJSON));
 

--- a/tests/sdk/flagsmith-cache.test.ts
+++ b/tests/sdk/flagsmith-cache.test.ts
@@ -14,7 +14,7 @@ test('test_empty_cache_not_read_but_populated', async () => {
   const allFlags = (await flg.getEnvironmentFlags()).allFlags();
 
   expect(set).toBeCalled();
-  expect(await cache.has('flags')).toBe(true);
+  expect(await cache.get('flags')).toBeTruthy();
 
   expect(fetch).toBeCalledTimes(1);
   expect(allFlags[0].enabled).toBe(true);
@@ -33,7 +33,7 @@ test('test_api_not_called_when_cache_present', async () => {
   const allFlags = await (await flg.getEnvironmentFlags()).allFlags();
 
   expect(set).toBeCalled();
-  expect(await cache.has('flags')).toBe(true);
+  expect(await cache.get('flags')).toBeTruthy();
 
   expect(fetch).toBeCalledTimes(1);
   expect(allFlags[0].enabled).toBe(true);
@@ -88,7 +88,7 @@ test('test_cache_used_for_identity_flags', async () => {
   const identityFlags = (await flg.getIdentityFlags(identifier, traits)).allFlags();
 
   expect(set).toBeCalled();
-  expect(await cache.has('flags-identifier')).toBe(true);
+  expect(await cache.get('flags-identifier')).toBeTruthy();
 
   expect(fetch).toBeCalledTimes(1);
 
@@ -115,7 +115,7 @@ test('test_cache_used_for_identity_flags_local_evaluation', async () => {
   const identityFlags = (await flg.getIdentityFlags(identifier, traits)).allFlags();
 
   expect(set).toBeCalled();
-  expect(await cache.has('flags-identifier')).toBe(true);
+  expect(await cache.get('flags-identifier')).toBeTruthy();
 
   expect(fetch).toBeCalledTimes(1);
 

--- a/tests/sdk/utils.ts
+++ b/tests/sdk/utils.ts
@@ -10,12 +10,8 @@ const DATA_DIR = __dirname + '/data/';
 export class TestCache implements FlagsmithCache {
     cache: Record<string, Flags> = {};
 
-    async get(name: string): Promise<Flags> {
+    async get(name: string): Promise<Flags | undefined> {
         return this.cache[name];
-    }
-
-    async has(name: string): Promise<boolean> {
-        return !!this.cache[name];
     }
 
     async set(name: string, value: Flags) {

--- a/tests/sdk/utils.ts
+++ b/tests/sdk/utils.ts
@@ -18,9 +18,8 @@ export class TestCache implements FlagsmithCache {
         return !!this.cache[name];
     }
 
-    async set(name: string, value: Flags, ttl: number|string) {
+    async set(name: string, value: Flags) {
         this.cache[name] = value;
-        return true
     }
 }
 


### PR DESCRIPTION
The `FlagsmithCache` interface is unnecessarily complicated:

* `has` is never used by the SDK, it is only used in tests. This change removes it.
* The return value of `set` is never used by the SDK, and serves no purpose. This changes `set` to be of type `Promise<void>`.
* `set` accepts a `ttl` parameter but the SDK never actually uses it. This change removes it.
* The return type of `get` used to be `Promise<Flags | undefined> | undefined`. In practice, the SDK always awaits this value so it should be `Promise<Flags | undefined>`, which is what this change uses.

The `Flagsmith` constructor also checks that the supplied cache has the same methods as the ones required by `FlagsmithCache`. This check is not thorough enough to be useful and should be done by typechecking. Also, this checking requires `FlagsmithCache` to be indexable by a string, which customers will never need to do and just adds boilerplate. This change removes this check and should be enforced by typechecking.

This change also adds JSDoc to `FlagsmithCache`, so we can [link to it directly](https://www.tsdocs.dev/docs/flagsmith-nodejs/4.0.0/interfaces/FlagsmithCache.html) from docs and avoid duplicating code snippets or explanations.

These are technically breaking changes, but only for TypeScript users and has no effect at runtime. Prior to 4.0.0 it was impossible to actually refer to the `FlagsmithCache` in TypeScript code because we were not exporting any types. I'd be okay with releasing it as `4.1.0`.