### PR TITLE
fix: Return 0 as number flag value instead of undefined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flagsmith-nodejs",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flagsmith-nodejs",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "pino": "^8.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-nodejs",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Flagsmith lets you manage features flags and remote config across web, mobile and server side applications. Deliver true Continuous Integration. Get builds out faster. Control who has access to new features.",
   "main": "./build/cjs/index.js",
   "type": "module",

--- a/sdk/models.ts
+++ b/sdk/models.ts
@@ -54,7 +54,7 @@ export class Flag extends BaseFlag {
     static fromAPIFlag(flagData: any): Flag {
         return new Flag({
             enabled: flagData['enabled'],
-            value: flagData['feature_state_value'] || flagData['value'],
+            value: flagData['feature_state_value'] ?? flagData['value'],
             featureId: flagData['feature']['id'],
             featureName: flagData['feature']['name']
         });


### PR DESCRIPTION
Couldn't figure out how to add a test case to https://github.com/Flagsmith/engine-test-data/blob/e43097ee273fa63dbb9589c02f89df3d10b51044/data/environment_n9fbf9h3v4fFgH3U3ngWhb.json - verified manually with the following test:

```js
// test.cjs

const Flagsmith = require('./build/cjs').Flagsmith

const flagsmith = new Flagsmith({
    environmentKey: 'LMVKS7tqAcQrjtsDWLoe7g',
});

const flags = await flagsmith.getEnvironmentFlags();
const value = flags.getFeatureValue('zero');

console.log(value);
```

Before:

```
rolodato@rolosmith flagsmith-nodejs-client % bun run build && bun test.cjs
$ rm -rf ./build
$ tsc -b tsconfig.cjs.json tsconfig.esm.json && echo '{"type": "commonjs"}'> build/cjs/package.json
undefined
```

After:

```
rolodato@rolosmith flagsmith-nodejs-client % bun run build && bun test.cjs 
$ rm -rf ./build
$ tsc -b tsconfig.cjs.json tsconfig.esm.json && echo '{"type": "commonjs"}'> build/cjs/package.json
0
```