### PR TITLE
feat: Allow configuring analytics API endpoint separate from flags API

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 export {
   AnalyticsProcessor,
+  AnalyticsProcessorOptions,
   FlagsmithAPIError,
   FlagsmithClientError,
   EnvironmentDataPollingManager,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flagsmith-nodejs",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flagsmith-nodejs",
-      "version": "5.0.1",
+      "version": "5.1.0",
       "license": "MIT",
       "dependencies": {
         "pino": "^8.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-nodejs",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Flagsmith lets you manage features flags and remote config across web, mobile and server side applications. Deliver true Continuous Integration. Get builds out faster. Control who has access to new features.",
   "main": "./build/cjs/index.js",
   "type": "module",

--- a/tests/sdk/analytics.test.ts
+++ b/tests/sdk/analytics.test.ts
@@ -26,7 +26,7 @@ test('test_analytics_processor_flush_post_request_data_match_ananlytics_data', a
     aP.trackFeature("myFeature2");
     await aP.flush();
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith('http://testUrlanalytics/flags/', expect.objectContaining({
+    expect(fetch).toHaveBeenCalledWith('http://testUrl/analytics/flags/', expect.objectContaining({
         body: '{"myFeature1":1,"myFeature2":1}',
         headers: { 'Content-Type': 'application/json', 'X-Environment-Key': 'test-key' },
         method: 'POST',

--- a/tests/sdk/utils.ts
+++ b/tests/sdk/utils.ts
@@ -24,7 +24,7 @@ export const fetch = vi.fn(global.fetch)
 export function analyticsProcessor() {
     return new AnalyticsProcessor({
         environmentKey: 'test-key',
-        baseApiUrl: 'http://testUrl',
+        analyticsUrl: 'http://testUrl/analytics/flags/',
         fetch,
     });
 }


### PR DESCRIPTION
Currently, we only support having the analytics API on the same host as the flags/identities endpoints. This is not the case when using the Edge Proxy, which does not accept analytics requests.

This change allows configuring an arbitrary analytics endpoint URL, and exports the `AnalyticsProcessor` + `AnalyticsProcessorOptions` types to allow manual analytics management.