### PR TITLE
feat: Export FeatureModel to enable custom offline handler

### DIFF
--- a/flagsmith-engine/index.ts
+++ b/flagsmith-engine/index.ts
@@ -7,7 +7,7 @@ import { SegmentModel } from './segments/models.js';
 import { FeatureStateNotFound } from './utils/errors.js';
 
 export { EnvironmentModel } from './environments/models.js';
-export { FeatureStateModel } from './features/models.js';
+export { FeatureModel, FeatureStateModel } from './features/models.js';
 export { IdentityModel } from './identities/models.js';
 export { TraitModel } from './identities/traits/models.js';
 export { SegmentModel } from './segments/models.js';

--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ export {
 
 export {
   EnvironmentModel,
+  FeatureModel,
   FeatureStateModel,
   IdentityModel,
   TraitModel,


### PR DESCRIPTION
Hi :wave:,

I'm experimenting with making a custom offline handler and was surprised that this class was not exported already, since it seems fairly necessary when using `FeatureStateModel`. For now I've had to  copy `FeatureModel` into my app code so it'd be great to have this exported so I didn't need to.