### PR TITLE
fix: removed-dango-id-usage-in-mapper

### DIFF
--- a/flagsmith-engine/evaluation/evaluationContext/mappers.ts
+++ b/flagsmith-engine/evaluation/evaluationContext/mappers.ts
@@ -127,10 +127,6 @@ function mapIdentityModelToIdentityContext(
         traits: traitsContext
     };
 
-    if (identity.djangoID !== undefined) {
-        identityContext.key = identity.djangoID.toString();
-    }
-
     return identityContext;
 }
 

--- a/tests/engine/unit/mappers.test.ts
+++ b/tests/engine/unit/mappers.test.ts
@@ -236,9 +236,7 @@ describe('getEvaluationContext', () => {
             [new TraitModel('email', 'test@example.com'), new TraitModel('age', 25)],
             [],
             'B62qaMZNwfiqT76p38ggrQ',
-            'test_user',
-            undefined,
-            123
+            'test_user'
         );
 
         // When
@@ -247,7 +245,6 @@ describe('getEvaluationContext', () => {
         // Then
         expect(context.identity).toBeDefined();
         expect(context.identity?.identifier).toBe('test_user');
-        expect(context.identity?.key).toBe('123');
         expect(context.identity?.traits).toEqual({
             email: 'test@example.com',
             age: 25

--- a/tests/engine/unit/segments/segment_evaluators.test.ts
+++ b/tests/engine/unit/segments/segment_evaluators.test.ts
@@ -82,49 +82,6 @@ test('test_traits_match_segment_condition_for_trait_existence_operators', () => 
     }
 });
 
-test('getIdentitySegments uses django ID for hashed percentage when present', () => {
-    var identityModel = new IdentityModel(
-        Date.now().toString(),
-        [],
-        [],
-        environment().apiKey,
-        'identity_1',
-        undefined,
-        1
-    );
-    const segmentDefinition = {
-        id: 1,
-        name: 'percentage_split_segment',
-        rules: [
-            {
-                type: ALL_RULE,
-                conditions: [
-                    {
-                        operator: PERCENTAGE_SPLIT,
-                        property_: null,
-                        value: '10'
-                    }
-                ],
-                rules: []
-            }
-        ],
-        feature_states: []
-    };
-    const segmentModel = buildSegmentModel(segmentDefinition);
-    const environmentModel = environment();
-    environmentModel.project.segments = [segmentModel];
-    const context = getEvaluationContext(environmentModel, identityModel);
-
-    var result = getIdentitySegments(context);
-
-    expect(result).toHaveLength(1);
-    expect(getHashedPercentageForObjIds).toHaveBeenCalledTimes(1);
-    expect(getHashedPercentageForObjIds).toHaveBeenCalledWith([
-        result[0].key,
-        context.identity!.key
-    ]);
-});
-
 describe('getIdentitySegments integration', () => {
     test('returns only matching segments', () => {
         const context: EvaluationContext = {


### PR DESCRIPTION
Removed (unused) mapper from `django_id` to `identityContext.key`