### PR TITLE
fix: include-identity-traits-in-cache-key

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+Thanks for submitting a PR! Please check the boxes below:
+
+-   [ ] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
+-   [ ] I have added information to `docs/` if required so people know about the feature.
+-   [ ] I have filled in the "Changes" section below.
+-   [ ] I have filled in the "How did you test this code" section below.
+
+## Changes
+
+Contributes to <!-- insert issue # or URL -->
+
+<!-- Change "Contributes to" to "Closes" if this PR, when merged, completely resolves the referenced issue.
+Leave "Contributes to" if the changes need to be released first. -->
+
+_Please describe._
+
+## How did you test this code?
+
+<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->
+
+_Please describe._

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -11,6 +11,7 @@ import { EnvironmentDataPollingManager } from './polling_manager.js';
 import {
     Deferred,
     generateIdentitiesData,
+    generateIdentityCacheKey,
     getUserAgent,
     isTraitConfig,
     retryFetch
@@ -226,7 +227,8 @@ export class Flagsmith {
             throw new Error('`identifier` argument is missing or invalid.');
         }
 
-        const cachedItem = !!this.cache && (await this.cache.get(`flags-${identifier}`));
+        const cacheKey = generateIdentityCacheKey(identifier, traits);
+        const cachedItem = !!this.cache && (await this.cache.get(cacheKey));
         if (!!cachedItem) {
             return cachedItem;
         }
@@ -497,7 +499,7 @@ export class Flagsmith {
         );
 
         if (!!this.cache) {
-            await this.cache.set(`flags-${identifier}`, flags);
+            await this.cache.set(generateIdentityCacheKey(identifier, traits), flags);
         }
 
         return flags;
@@ -535,7 +537,7 @@ export class Flagsmith {
             defaultFlagHandler: this.defaultFlagHandler
         });
         if (!!this.cache) {
-            await this.cache.set(`flags-${identifier}`, flags);
+            await this.cache.set(generateIdentityCacheKey(identifier, traits), flags);
         }
         return flags;
     }

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { Fetch, FlagsmithTraitValue, TraitConfig } from './types.js';
 import { Dispatcher } from 'undici-types';
 
@@ -38,6 +39,28 @@ export function generateIdentitiesData(identifier: string, traits: Traits, trans
         identifier: identifier,
         traits: traitsGenerated
     };
+}
+
+export function generateIdentityCacheKey(identifier: string, traits?: Traits): string {
+    if (!traits || Object.keys(traits).length === 0) {
+        return `flags-${identifier}`;
+    }
+
+    const normalized: [string, FlagsmithTraitValue][] = [];
+    for (const key of Object.keys(traits).sort()) {
+        const raw = traits[key];
+        const value = isTraitConfig(raw) ? raw.value : raw;
+        if (value === undefined) continue;
+        normalized.push([key, value]);
+    }
+
+    if (normalized.length === 0) {
+        return `flags-${identifier}`;
+    }
+
+    const serialized = JSON.stringify(normalized);
+    const hash = createHash('sha256').update(serialized).digest('hex').substring(0, 16);
+    return `flags-${identifier}-${hash}`;
 }
 
 export const delay = (ms: number) =>

--- a/tests/sdk/flagsmith-cache.test.ts
+++ b/tests/sdk/flagsmith-cache.test.ts
@@ -129,7 +129,6 @@ test('test_different_traits_produce_different_cache_entries', async () => {
     await flg.getIdentityFlags(identifier, { some_trait: 'value_a' });
     await flg.getIdentityFlags(identifier, { some_trait: 'value_b' });
 
-    // Different traits should hit the API separately, not return stale cached results.
     expect(fetch).toBeCalledTimes(2);
     expect(Object.keys(cache.cache).length).toBe(2);
 });

--- a/tests/sdk/flagsmith-cache.test.ts
+++ b/tests/sdk/flagsmith-cache.test.ts
@@ -7,6 +7,7 @@ import {
     identitiesJSON,
     TestCache
 } from './utils.js';
+import { generateIdentityCacheKey } from '../../sdk/utils.js';
 
 test('test_empty_cache_not_read_but_populated', async () => {
     const cache = new TestCache();
@@ -86,7 +87,7 @@ test('test_cache_used_for_identity_flags', async () => {
     const identityFlags = (await flg.getIdentityFlags(identifier, traits)).allFlags();
 
     expect(set).toBeCalled();
-    expect(await cache.get('flags-identifier')).toBeTruthy();
+    expect(await cache.get(generateIdentityCacheKey(identifier, traits))).toBeTruthy();
 
     expect(fetch).toBeCalledTimes(1);
 
@@ -111,11 +112,24 @@ test('test_cache_used_for_identity_flags_local_evaluation', async () => {
     const identityFlags = (await flg.getIdentityFlags(identifier, traits)).allFlags();
 
     expect(set).toBeCalled();
-    expect(await cache.get('flags-identifier')).toBeTruthy();
+    expect(await cache.get(generateIdentityCacheKey(identifier, traits))).toBeTruthy();
 
     expect(fetch).toBeCalledTimes(1);
 
     expect(identityFlags[0].enabled).toBe(true);
     expect(identityFlags[0].value).toBe('some-value');
     expect(identityFlags[0].featureName).toBe('some_feature');
+});
+
+test('test_different_traits_produce_different_cache_entries', async () => {
+    const cache = new TestCache();
+    const identifier = 'identifier';
+    const flg = flagsmith({ cache });
+
+    await flg.getIdentityFlags(identifier, { some_trait: 'value_a' });
+    await flg.getIdentityFlags(identifier, { some_trait: 'value_b' });
+
+    // Different traits should hit the API separately, not return stale cached results.
+    expect(fetch).toBeCalledTimes(2);
+    expect(Object.keys(cache.cache).length).toBe(2);
 });


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

-   [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
-   [x] I have added information to `docs/` if required so people know about the feature.
-   [x] I have filled in the "Changes" section below.
-   [x] I have filled in the "How did you test this code" section below.

## Changes

Closes #238 

Chose option 2 (include traits in cache key) from the proposed solutions as 1 (new boolean sdk option) is just covering the bug while adding complexity
- New `generateIdentityCacheKey` that hash sorted and normalized traits in the cache key (same `flags-{identifier}` key if no traits)
- Updated call sites and tests

## How did you test this code?
- New test exposing the bug turned green
- Updated tests