### PR TITLE
ci: setup Renovate for engine-test-data tracking

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended", ":semanticCommitScopeDisabled"],
+    "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
+    "semanticCommitType": "deps",
+    "git-submodules": { "enabled": true },
+    "packageRules": [
+        {
+            "matchUpdateTypes": [
+                "major",
+                "minor",
+                "patch",
+                "digest",
+                "pin",
+                "rollback",
+                "bump",
+                "replacement",
+                "lockFileMaintenance"
+            ],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["git-submodules"],
+            "enabled": true
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Adds Renovate configuration to automatically track `engine-test-data` submodule updates and security vulnerabilities.

| Rule | Effect |
|---|---|
| `extends: config:recommended` | Renovate defaults (Dependency Dashboard, etc.) |
| Disable all routine updates | All `matchUpdateTypes` except `vulnerabilityAlerts` → blocked |
| Enable git-submodules | Tracks `engine-test-data` releases and opens PRs |
| **CVE / security alerts** | Pass through (not in disabled list) |

**Net effect**: only two things trigger PRs — a new `engine-test-data` release, or a CVE on any dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)