### PR TITLE
fix: respect rule type for sub-rules in segment evaluation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tests/engine/engine-tests/engine-test-data"]
 	path = tests/engine/engine-tests/engine-test-data
 	url = git@github.com:Flagsmith/engine-test-data.git
-	branch = v3.5.0
+	branch = v3.7.0

--- a/flagsmith-engine/segments/evaluators.ts
+++ b/flagsmith-engine/segments/evaluators.ts
@@ -119,9 +119,11 @@ function evaluateSubRules(
 ): boolean {
     if (!rule.rules || rule.rules.length === 0) return true;
 
-    return rule.rules.every((subRule: SegmentRule) =>
+    const subRuleResults = rule.rules.map((subRule: SegmentRule) =>
         traitsMatchSegmentRule(subRule, segmentKey, context)
     );
+
+    return evaluateRuleConditions(rule.type, subRuleResults);
 }
 
 function evaluateRuleConditions(ruleType: string, conditionResults: boolean[]): boolean {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

- Bumped engine-test-data submodule from v3.5.0 to v3.7.0
- Fixed segment evaluation: sub-rules now respect the parent rule's type (ANY/ALL/NONE) instead of hardcoding ALL

Equivalent fix to [flagsmith-engine#313](https://github.com/Flagsmith/flagsmith-engine/pull/313).

## How did you test this code?

- engine-test-data v3.7.0 includes 3 new test cases for sub-rule type handling
- All existing + new tests pass (380/380)