### PR TITLE
fix: handle BigInt variant priority in local evaluation of multivariate identity overrides

### DIFF
--- a/flagsmith-engine/evaluation/evaluationContext/mappers.ts
+++ b/flagsmith-engine/evaluation/evaluationContext/mappers.ts
@@ -173,10 +173,10 @@ function mapIdentityOverridesToSegments(
 
         const overridesHash = createHash('sha1')
             .update(
-                JSON.stringify(overridesKey, (key, value) => {
-                    if (key === 'key') return undefined;
-                    return typeof value === 'bigint' ? value.toString() : value;
-                })
+                JSON.stringify(
+                    overridesKey.map(({ key, ...rest }) => rest),
+                    (_, value) => (typeof value === 'bigint' ? value.toString() : value)
+                )
             )
             .digest('hex');
 

--- a/flagsmith-engine/evaluation/evaluationContext/mappers.ts
+++ b/flagsmith-engine/evaluation/evaluationContext/mappers.ts
@@ -160,6 +160,7 @@ function mapIdentityOverridesToSegments(
             a.feature.name.localeCompare(b.feature.name)
         );
         const overridesKey = sortedFeatures.map(fs => ({
+            key: fs.djangoID?.toString() || fs.featurestateUUID,
             name: fs.feature.name,
             enabled: fs.enabled,
             value: fs.getValue(),
@@ -170,7 +171,14 @@ function mapIdentityOverridesToSegments(
             }
         }));
 
-        const overridesHash = createHash('sha1').update(JSON.stringify(overridesKey)).digest('hex');
+        const overridesHash = createHash('sha1')
+            .update(
+                JSON.stringify(overridesKey, (key, value) => {
+                    if (key === 'key') return undefined;
+                    return typeof value === 'bigint' ? value.toString() : value;
+                })
+            )
+            .digest('hex');
 
         if (!featuresToIdentifiers.has(overridesHash)) {
             featuresToIdentifiers.set(overridesHash, { identifiers: [], overrides: overridesKey });

--- a/flagsmith-engine/index.ts
+++ b/flagsmith-engine/index.ts
@@ -192,7 +192,11 @@ function getMultivariateFeatureValue(
 ): { value: any; reason?: string } {
     const percentageValue = getHashedPercentageForObjIds([feature.key, identityKey]);
     const sortedVariants = [...(feature?.variants || [])].sort((a, b) => {
-        return (a.priority ?? Infinity) - (b.priority ?? Infinity);
+        const aPriority = a.priority ?? Infinity;
+        const bPriority = b.priority ?? Infinity;
+        if (aPriority < bPriority) return -1;
+        if (aPriority > bPriority) return 1;
+        return 0;
     });
 
     let startPercentage = 0;

--- a/tests/engine/unit/mappers.test.ts
+++ b/tests/engine/unit/mappers.test.ts
@@ -350,4 +350,94 @@ describe('getEvaluationContext', () => {
         expect(overrideSegments[0].rules?.[0].conditions?.[0].value).toContain('overridden-id');
         expect(overrideSegments[0].overrides?.length).toBe(1);
     });
+
+    // Regression: identity override on a multivariate flag whose mv values have no
+    // django `id` made mapIdentityOverridesToSegments JSON.stringify a BigInt priority.
+    test('handles identity override on a multivariate feature without django ids', () => {
+        const envWithMvOverride = JSON.parse(JSON.stringify(environmentJSON));
+        envWithMvOverride.identity_overrides = [
+            {
+                identifier: 'overridden-mv-identifier',
+                identity_uuid: '11111111-1111-1111-1111-111111111111',
+                environment_api_key: 'B62qaMZNwfiqT76p38ggrQ',
+                identity_features: [
+                    {
+                        feature: { id: 2, name: 'mv_feature', type: 'MULTIVARIATE' },
+                        featurestate_uuid: '22222222-2222-2222-2222-222222222222',
+                        feature_state_value: 'control',
+                        enabled: true,
+                        feature_segment: null,
+                        multivariate_feature_state_values: [
+                            {
+                                percentage_allocation: 33,
+                                multivariate_feature_option: { value: 'variant_1' },
+                                mv_fs_value_uuid: 'aaaaaaaa-0000-0000-0000-000000000001'
+                            },
+                            {
+                                percentage_allocation: 33,
+                                multivariate_feature_option: { value: 'variant_2' },
+                                mv_fs_value_uuid: 'aaaaaaaa-0000-0000-0000-000000000002'
+                            },
+                            {
+                                percentage_allocation: 34,
+                                multivariate_feature_option: { value: 'variant_3' },
+                                mv_fs_value_uuid: 'aaaaaaaa-0000-0000-0000-000000000003'
+                            }
+                        ]
+                    }
+                ]
+            }
+        ];
+        const env = buildEnvironmentModel(envWithMvOverride);
+
+        expect(() => getEvaluationContext(env)).not.toThrow();
+
+        const context = getEvaluationContext(env);
+        const overrideSegment = Object.values(context.segments!).find(
+            s =>
+                s.name === IDENTITY_OVERRIDE_SEGMENT_NAME &&
+                s.rules?.[0]?.conditions?.[0]?.value === 'overridden-mv-identifier'
+        );
+        expect(overrideSegment).toBeDefined();
+        const mvOverride = overrideSegment!.overrides?.find(o => o.name === 'mv_feature');
+        expect(mvOverride).toBeDefined();
+        expect(mvOverride!.variants?.length).toBe(3);
+        expect(mvOverride!.variants?.map(v => v.value)).toEqual([
+            'variant_1',
+            'variant_2',
+            'variant_3'
+        ]);
+        expect(mvOverride!.key).toBe('22222222-2222-2222-2222-222222222222');
+    });
+
+    test('still dedupes identical plain identity overrides into one segment', () => {
+        const envWithDupes = JSON.parse(JSON.stringify(environmentJSON));
+        const makeOverride = (identifier: string, fsUuid: string) => ({
+            identifier,
+            identity_uuid: identifier,
+            environment_api_key: 'B62qaMZNwfiqT76p38ggrQ',
+            identity_features: [
+                {
+                    feature: { id: 1, name: 'some_feature', type: 'STANDARD' },
+                    featurestate_uuid: fsUuid,
+                    feature_state_value: 'shared-override-value',
+                    enabled: false,
+                    feature_segment: null
+                }
+            ]
+        });
+        envWithDupes.identity_overrides = [
+            makeOverride('user-a', '33333333-3333-3333-3333-333333333333'),
+            makeOverride('user-b', '44444444-4444-4444-4444-444444444444')
+        ];
+        const env = buildEnvironmentModel(envWithDupes);
+
+        const context = getEvaluationContext(env);
+        const overrideSegments = Object.values(context.segments!).filter(
+            s => s.name === IDENTITY_OVERRIDE_SEGMENT_NAME
+        );
+
+        expect(overrideSegments.length).toBe(1);
+        expect(overrideSegments[0].rules?.[0].conditions?.[0].value).toBe('user-a,user-b');
+    });
 });

--- a/tests/sdk/flagsmith-identity-flags.test.ts
+++ b/tests/sdk/flagsmith-identity-flags.test.ts
@@ -138,6 +138,56 @@ test('test_get_identity_flags_multivariate_value_with_local_evaluation_enabled',
     expect(identityFlags.isFeatureEnabled('mv_feature')).toBe(false);
 });
 
+// Regression: local-evaluation getIdentityFlags() threw "Do not know how to
+// serialize a BigInt" when an identity override targeted a multivariate flag.
+test('getIdentityFlags local evaluation with multivariate identity override does not crash', async () => {
+    const envWithMvOverride = JSON.parse(environmentJSON);
+    envWithMvOverride.identity_overrides = [
+        {
+            identifier: 'overridden-mv-identifier',
+            identity_uuid: '11111111-1111-1111-1111-111111111111',
+            environment_api_key: 'B62qaMZNwfiqT76p38ggrQ',
+            identity_features: [
+                {
+                    feature: { id: 2, name: 'mv_feature', type: 'MULTIVARIATE' },
+                    featurestate_uuid: '22222222-2222-2222-2222-222222222222',
+                    feature_state_value: 'control',
+                    enabled: true,
+                    feature_segment: null,
+                    multivariate_feature_state_values: [
+                        {
+                            percentage_allocation: 33,
+                            multivariate_feature_option: { value: 'variant_1' },
+                            mv_fs_value_uuid: 'aaaaaaaa-0000-0000-0000-000000000001'
+                        },
+                        {
+                            percentage_allocation: 33,
+                            multivariate_feature_option: { value: 'variant_2' },
+                            mv_fs_value_uuid: 'aaaaaaaa-0000-0000-0000-000000000002'
+                        },
+                        {
+                            percentage_allocation: 34,
+                            multivariate_feature_option: { value: 'variant_3' },
+                            mv_fs_value_uuid: 'aaaaaaaa-0000-0000-0000-000000000003'
+                        }
+                    ]
+                }
+            ]
+        }
+    ];
+    fetch.mockResolvedValue(new Response(JSON.stringify(envWithMvOverride)));
+
+    const flg = flagsmith({
+        environmentKey: 'ser.key',
+        enableLocalEvaluation: true
+    });
+
+    const flags = await flg.getIdentityFlags('overridden-mv-identifier');
+
+    expect(flags.isFeatureEnabled('mv_feature')).toBe(true);
+    expect(['variant_1', 'variant_2', 'variant_3']).toContain(flags.getFeatureValue('mv_feature'));
+});
+
 test('test_transient_identity', async () => {
     fetch.mockResolvedValue(new Response(transientIdentityJSON));
     const identifier = 'transient_identifier';


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature. <!-- N/A, bug fix -->
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes

Fixes a crash in **local evaluation** of multivariate flags. When an environment contains an identity override on a multivariate flag whose multivariate values have no django `id` (only `mv_fs_value_uuid`, as in real environment documents)
- `getIdentityFlags()` threw `TypeError: Do not know how to serialize a BigInt`

Root cause: a variant's `priority` is a `BigInt` when derived from a uuid like in the python implementation and core engine and ordering. 

Fixed two not BigInt-safe consumers:
- `mapIdentityOverridesToSegments`, where `JSON.stringify` of the override dedup key threw on the BigInt.
- `getMultivariateFeatureValue`, where the sort comparator returned a `BigInt` (`a.priority - b.priority`), which `Array.sort` cannot coerce (`Cannot convert a BigInt value to a number`).

## How did you test this code?
Added regression tests that reproduce the exact same regression, confirmed they fail on `main` with the reported error, then pass with the fix:
- `tests/engine/unit/mappers.test.ts`: identity override on a multivariate flag without django ids (no throw, variants mapped, correct `key`), and identical plain overrides still dedupe into one segment.
- `tests/sdk/flagsmith-identity-flags.test.ts`: `getIdentityFlags` with `enableLocalEvaluation: true` no longer crashes and resolves to a variant.
