### PR TITLE
fix: inline SDK version instead of reading package.json at runtime

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,8 @@
             "bump-patch-for-minor-pre-major": false,
             "draft": false,
             "prerelease": false,
-            "include-component-in-tag": false
+            "include-component-in-tag": false,
+            "extra-files": ["sdk/version.ts"]
         }
     },
     "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -1,11 +1,11 @@
 import { createHash } from 'crypto';
 import { Fetch, FlagsmithTraitValue, TraitConfig } from './types.js';
 import { Dispatcher } from 'undici-types';
+import { SDK_VERSION } from './version.js';
 
 type Traits = { [key: string]: TraitConfig | FlagsmithTraitValue };
 
 const FLAGSMITH_USER_AGENT = 'flagsmith-nodejs-sdk';
-const FLAGSMITH_UNKNOWN_VERSION = 'unknown';
 
 export function isTraitConfig(
     traitValue: TraitConfig | FlagsmithTraitValue
@@ -130,11 +130,5 @@ export class Deferred<T> {
 }
 
 export function getUserAgent(): string {
-    try {
-        const packageJson = require('../package.json');
-        const version = packageJson?.version;
-        return version ? `${FLAGSMITH_USER_AGENT}/${version}` : FLAGSMITH_UNKNOWN_VERSION;
-    } catch {
-        return FLAGSMITH_UNKNOWN_VERSION;
-    }
+    return `${FLAGSMITH_USER_AGENT}/${SDK_VERSION}`;
 }

--- a/sdk/version.ts
+++ b/sdk/version.ts
@@ -1,0 +1,1 @@
+export const SDK_VERSION = '9.0.1'; // x-release-please-version

--- a/tests/sdk/flagsmith.test.ts
+++ b/tests/sdk/flagsmith.test.ts
@@ -512,8 +512,7 @@ test('getIdentityFlags succeeds if initial fetch failed then succeeded', async (
     expect(flags2.isFeatureEnabled('some_feature')).toBe(true);
 });
 
-// Skip in ESM build: require() path resolution differs
-test.skipIf(isEsmBuild)('get_user_agent_extracts_version_from_package_json', async () => {
+test('get_user_agent_matches_package_version', async () => {
     const userAgent = getUserAgent();
     const packageJson = require('../../package.json');
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

-   [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
-   [ ] I have added information to `docs/` if required so people know about the feature.
-   [x] I have filled in the "Changes" section below.
-   [x] I have filled in the "How did you test this code" section below.

## Changes

`getUserAgent()` read the SDK version with `require('../package.json')` at request time. This never worked in the published package (the relative path resolves to `build/esm/package.json` or the `build/cjs/package.json` stub, so the header always reported `unknown`), and under bundlers such as Vite the `require` can be rewritten into a form that escapes the `try/catch` and crashes the host application.

- Inline the version in a committed `sdk/version.ts` constant; no filesystem or `require` access at runtime.
- Register `sdk/version.ts` as a release-please `extra-files` entry so the constant is bumped on every release.
- Un-skip the ESM user-agent test, which now passes against the real package version.

## How did you test this code?

- `npm test` and `npm run test:esm-build` pass.
- Built and packed the SDK, bundled a Fastify server with `vite build --ssr` (Vite 8), ran the bundle from a separate directory: the request sends `User-Agent: flagsmith-nodejs-sdk/9.0.1` and the bundle contains no `package.json` reference.
