### PR TITLE
fix: fall back to unknown version if SDK_VERSION is unavailable

### DIFF
--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -6,6 +6,7 @@ import { SDK_VERSION } from './version.js';
 type Traits = { [key: string]: TraitConfig | FlagsmithTraitValue };
 
 const FLAGSMITH_USER_AGENT = 'flagsmith-nodejs-sdk';
+const FLAGSMITH_UNKNOWN_VERSION = 'unknown';
 
 export function isTraitConfig(
     traitValue: TraitConfig | FlagsmithTraitValue
@@ -130,5 +131,7 @@ export class Deferred<T> {
 }
 
 export function getUserAgent(): string {
-    return `${FLAGSMITH_USER_AGENT}/${SDK_VERSION}`;
+    const version =
+        typeof SDK_VERSION === 'string' && SDK_VERSION ? SDK_VERSION : FLAGSMITH_UNKNOWN_VERSION;
+    return `${FLAGSMITH_USER_AGENT}/${version}`;
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

-   [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
-   [ ] I have added information to `docs/` if required so people know about the feature.
-   [x] I have filled in the "Changes" section below.
-   [x] I have filled in the "How did you test this code" section below.

## Changes

Follow-up to #294. `getUserAgent()` now falls back to `flagsmith-nodejs-sdk/unknown` if `SDK_VERSION` is ever missing or empty, so the header can never throw regardless of how the package is bundled.

## How did you test this code?

- `npm test` passes; `get_user_agent_matches_package_version` still asserts the real version is sent.
